### PR TITLE
detect CRAM or BAM based on the input binary file header

### DIFF
--- a/bin/speedseq
+++ b/bin/speedseq
@@ -91,15 +91,43 @@ function check_python_modules() {
     fi
 }
 
-# Check if a file is a cram based on the file extension
-function is_cram ()
-{
-    FILENAME="$1"
-    FILE_EXTENSION="${FILENAME##*.}"
-    if [[ "$FILE_EXTENSION" == "cram" || "$FILE_EXTENSION" == "CRAM" ]]; then
-        return 0
+# Check if a file is a cram or bam based on the binary header
+function is_cram () {
+    local file_path=$1
+
+    header=$(hexdump -n 4 -e '"%c"' ${file_path})
+    if [ ${header} == 'CRAM' ]; then
+        result=0
     else
-        return 1
+        result=1
+    fi
+
+    return ${result}
+}
+
+function is_bam () {
+    local file_path=$1
+    local result=1
+
+    is_gzipped=$(hexdump -n 2 -e '"%x"' ${file_path})
+    if [ ${is_gzipped} = '8b1f' ]; then
+        is_bam=$(zcat ${file_path} | hexdump -n 3 -e '"%c"')
+        if [ ${is_bam} = 'BAM' ]; then
+            result=0
+        fi
+    fi
+
+    return ${result}
+}
+
+# ensure that we have a valid CRAM or BAM file
+function check_valid_cram_or_bam () {
+    local input_path=$1
+    if is_cram ${input_path} || is_bam ${input_path} ; then
+        echo -e "${input_path} is a valid CRAM/BAM file"
+    else
+        echo -e "${input_path}: is NOT a valid CRAM/BAM file!"
+        exit 1
     fi
 }
 
@@ -1483,6 +1511,7 @@ global options:
 	for i in $( seq 0 $(( ${#FULL_BAM_LIST[@]}-1 )) )
 	do
 	    FULL_BAM=${FULL_BAM_LIST[$i]}
+	    check_valid_cram_or_bam ${FULL_BAM}
 	    FULL_BASE=`basename $FULL_BAM`
 	    CRAM_OPTS=""
 	    if is_cram $FULL_BAM; then


### PR DESCRIPTION
Use `hexdump` to interrogate the BAM or CRAM file header and ascertain the file type.  This makes the input file detection process more robust.

Additionally, I put in an error check to error and exit out if an input file isn't a proper BAM or CRAM.